### PR TITLE
Extra tests that check the value

### DIFF
--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -67,29 +67,33 @@ class TestPythonApi(unittest.TestCase):
 
     def test_bounding_box_size_with_expand(self):
 
-        my_bb = DagmcBoundingBox(self.h5m_filename_bigger).corners(expand=(100,200,300))
+        my_bb = DagmcBoundingBox(self.h5m_filename_bigger).corners(
+            expand=(100, 200, 300)
+        )
 
         print(my_bb)
         assert len(my_bb) == 2
         assert len(my_bb[0]) == 3
         assert len(my_bb[1]) == 3
-        assert my_bb[0][0] == pytest.approx(-10005-100, abs=0.1)
-        assert my_bb[0][1] == pytest.approx(-10005-200, abs=0.1)
-        assert my_bb[0][2] == pytest.approx(-10005-300, abs=0.1)
-        assert my_bb[1][0] == pytest.approx(10005+100, abs=0.1)
-        assert my_bb[1][1] == pytest.approx(10005+200, abs=0.1)
-        assert my_bb[1][2] == pytest.approx(10005+300, abs=0.1)
+        assert my_bb[0][0] == pytest.approx(-10005 - 100, abs=0.1)
+        assert my_bb[0][1] == pytest.approx(-10005 - 200, abs=0.1)
+        assert my_bb[0][2] == pytest.approx(-10005 - 300, abs=0.1)
+        assert my_bb[1][0] == pytest.approx(10005 + 100, abs=0.1)
+        assert my_bb[1][1] == pytest.approx(10005 + 200, abs=0.1)
+        assert my_bb[1][2] == pytest.approx(10005 + 300, abs=0.1)
 
     def test_bounding_box_size_2_with_expand(self):
 
-        my_bb = DagmcBoundingBox(self.h5m_filename_smaller).corners(expand=(100,200,300))
+        my_bb = DagmcBoundingBox(self.h5m_filename_smaller).corners(
+            expand=(100, 200, 300)
+        )
 
         assert len(my_bb) == 2
         assert len(my_bb[0]) == 3
         assert len(my_bb[1]) == 3
-        assert my_bb[0][0] == pytest.approx(-10005-100, abs=0.1)
-        assert my_bb[0][1] == pytest.approx(-10005-200, abs=0.1)
-        assert my_bb[0][2] == pytest.approx(-10005-300, abs=0.1)
-        assert my_bb[1][0] == pytest.approx(10005+100, abs=0.1)
-        assert my_bb[1][1] == pytest.approx(10005+200, abs=0.1)
-        assert my_bb[1][2] == pytest.approx(10005+300, abs=0.1)
+        assert my_bb[0][0] == pytest.approx(-10005 - 100, abs=0.1)
+        assert my_bb[0][1] == pytest.approx(-10005 - 200, abs=0.1)
+        assert my_bb[0][2] == pytest.approx(-10005 - 300, abs=0.1)
+        assert my_bb[1][0] == pytest.approx(10005 + 100, abs=0.1)
+        assert my_bb[1][1] == pytest.approx(10005 + 200, abs=0.1)
+        assert my_bb[1][2] == pytest.approx(10005 + 300, abs=0.1)

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -3,6 +3,7 @@ import tarfile
 import unittest
 import urllib.request
 from pathlib import Path
+import pytest
 
 from dagmc_bounding_box import DagmcBoundingBox
 
@@ -24,30 +25,71 @@ class TestPythonApi(unittest.TestCase):
         self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.2/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
 
     def test_corners_returns_correct_type(self):
-        dagmc_filename = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-        my_bb = DagmcBoundingBox(dagmc_filename).corners()
-        assert isinstance(my_bb, tuple)
-        assert isinstance(my_bb[0], tuple)
-        assert isinstance(my_bb[1], tuple)
-        assert isinstance(my_bb[0][0], float)
-        assert isinstance(my_bb[0][1], float)
-        assert isinstance(my_bb[0][2], float)
-        assert isinstance(my_bb[1][0], float)
-        assert isinstance(my_bb[1][1], float)
-        assert isinstance(my_bb[1][2], float)
+
+        for dagmc_filename in [self.h5m_filename_smaller, self.h5m_filename_bigger]:
+            my_bb = DagmcBoundingBox(dagmc_filename).corners()
+            assert isinstance(my_bb, tuple)
+            assert isinstance(my_bb[0], tuple)
+            assert isinstance(my_bb[1], tuple)
+            assert isinstance(my_bb[0][0], float)
+            assert isinstance(my_bb[0][1], float)
+            assert isinstance(my_bb[0][2], float)
+            assert isinstance(my_bb[1][0], float)
+            assert isinstance(my_bb[1][1], float)
+            assert isinstance(my_bb[1][2], float)
+            assert len(my_bb) == 2
+            assert len(my_bb[0]) == 3
+            assert len(my_bb[1]) == 3
+
+    def test_corners_relative_magnitude(self):
+
+        for dagmc_filename in [self.h5m_filename_smaller, self.h5m_filename_bigger]:
+            my_bb = DagmcBoundingBox(dagmc_filename).corners()
+
+            assert my_bb[0][0] < my_bb[1][0]
+            assert my_bb[0][1] < my_bb[1][1]
+            assert my_bb[0][2] < my_bb[1][2]
+
+    def test_bounding_box_size(self):
+
+        my_bb = DagmcBoundingBox(self.h5m_filename_bigger).corners()
+
+        print(my_bb)
         assert len(my_bb) == 2
         assert len(my_bb[0]) == 3
         assert len(my_bb[1]) == 3
+        assert my_bb[0][0] == pytest.approx(-10005, abs=0.1)
+        assert my_bb[0][1] == pytest.approx(-10005, abs=0.1)
+        assert my_bb[0][2] == pytest.approx(-10005, abs=0.1)
+        assert my_bb[1][0] == pytest.approx(10005, abs=0.1)
+        assert my_bb[1][1] == pytest.approx(10005, abs=0.1)
+        assert my_bb[1][2] == pytest.approx(10005, abs=0.1)
 
-    def test_corners_relative_magnitude(self):
-        dagmc_filename = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-        my_bb = DagmcBoundingBox(dagmc_filename).corners()
+    def test_bounding_box_size_with_expand(self):
 
-        assert my_bb[0][0] < my_bb[1][0]
-        assert my_bb[0][1] < my_bb[1][1]
-        assert my_bb[0][2] < my_bb[1][2]
+        my_bb = DagmcBoundingBox(self.h5m_filename_bigger).corners(expand=(100,200,300))
 
+        print(my_bb)
+        assert len(my_bb) == 2
+        assert len(my_bb[0]) == 3
+        assert len(my_bb[1]) == 3
+        assert my_bb[0][0] == pytest.approx(-10005-100, abs=0.1)
+        assert my_bb[0][1] == pytest.approx(-10005-200, abs=0.1)
+        assert my_bb[0][2] == pytest.approx(-10005-300, abs=0.1)
+        assert my_bb[1][0] == pytest.approx(10005+100, abs=0.1)
+        assert my_bb[1][1] == pytest.approx(10005+200, abs=0.1)
+        assert my_bb[1][2] == pytest.approx(10005+300, abs=0.1)
 
-# TODO add a test to check the correct values are found
+    def test_bounding_box_size_2_with_expand(self):
 
-# TODO add a test to check that extend increases the values correctly
+        my_bb = DagmcBoundingBox(self.h5m_filename_smaller).corners(expand=(100,200,300))
+
+        assert len(my_bb) == 2
+        assert len(my_bb[0]) == 3
+        assert len(my_bb[1]) == 3
+        assert my_bb[0][0] == pytest.approx(-10005-100, abs=0.1)
+        assert my_bb[0][1] == pytest.approx(-10005-200, abs=0.1)
+        assert my_bb[0][2] == pytest.approx(-10005-300, abs=0.1)
+        assert my_bb[1][0] == pytest.approx(10005+100, abs=0.1)
+        assert my_bb[1][1] == pytest.approx(10005+200, abs=0.1)
+        assert my_bb[1][2] == pytest.approx(10005+300, abs=0.1)


### PR DESCRIPTION
These tests were based on tests from openmc dagmc wrapper when the functionality resided in the package.

the tests check the values returned for a known bounding box with and without the expand option

@RemDelaporteMathurin this movement of code means we can close https://github.com/fusion-energy/openmc-dagmc-wrapper/pull/87